### PR TITLE
Fix build error with `hold_position_server.cpp`

### DIFF
--- a/zebROS_ws/src/path_follower/src/hold_position_server.cpp
+++ b/zebROS_ws/src/path_follower/src/hold_position_server.cpp
@@ -435,7 +435,7 @@ int main(int argc, char **argv)
 	nh.getParam("/hold_position/hold_position/use_pose_for_odom", use_pose_for_odom);
 	nh.getParam("/hold_position/hold_position/dist_threshold", dist_threshold);
 	nh.getParam("/hold_position/hold_position/angle_threshold", angle_threshold);
-	ROS_WARN("DistanceThreshold: " << dist_threshold_ << " Angle Thresh:" << angle_threshold_);
+	ROS_WARN_STREAM("DistanceThreshold: " << dist_threshold << " Angle Thresh:" << angle_threshold);
 	holdPosition hold_position_server("hold_position_server", nh,
 								  server_timeout,
 								  ros_rate,


### PR DESCRIPTION
This fixes a build error I was getting in `hold_position_server.cpp` -- I think a print statement used `ROS_WARN` instead of `ROS_WARN_STREAM` and two variables had extra underscores. This was the error:
```Errors     << path_follower:make /home/ubuntu/2022RobotCode/zebROS_ws/logs/path_follower/build.make.038.log
/home/ubuntu/2022RobotCode/zebROS_ws/src/path_follower/src/hold_position_server.cpp: In function ‘int main(int, char**)’:
/home/ubuntu/2022RobotCode/zebROS_ws/src/path_follower/src/hold_position_server.cpp:438:2: error: ‘dist_threshold_’ was not declared in this scope
  ROS_WARN("DistanceThreshold: " << dist_threshold_ << " Angle Thresh:" << angle_threshold_);
  ^~~~~~~~
/home/ubuntu/2022RobotCode/zebROS_ws/src/path_follower/src/hold_position_server.cpp:438:2: note: suggested alternative: ‘dist_threshold’
  ROS_WARN("DistanceThreshold: " << dist_threshold_ << " Angle Thresh:" << angle_threshold_);
  ^~~~~~~~
  dist_threshold
/home/ubuntu/2022RobotCode/zebROS_ws/src/path_follower/src/hold_position_server.cpp:438:2: error: ‘angle_threshold_’ was not declared in this scope
/home/ubuntu/2022RobotCode/zebROS_ws/src/path_follower/src/hold_position_server.cpp:438:2: note: suggested alternative: ‘angle_threshold’
  ROS_WARN("DistanceThreshold: " << dist_threshold_ << " Angle Thresh:" << angle_threshold_);
  ^~~~~~~~
  angle_threshold
make[2]: *** [CMakeFiles/hold_position_server.dir/build.make:76: CMakeFiles/hold_position_server.dir/src/hold_position_server.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1787: CMakeFiles/hold_position_server.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
cd /home/ubuntu/2022RobotCode/zebROS_ws/build/path_follower; catkin build --get-env path_follower | catkin env -si  /usr/bin/make --jobserver-auth=6,7; cd -
....................................................................................................```