### PR TITLE
Updates from Feb 28th testing

### DIFF
--- a/zebROS_ws/src/controller_node/launch/2022_compbot_jetson.launch
+++ b/zebROS_ws/src/controller_node/launch/2022_compbot_jetson.launch
@@ -65,16 +65,16 @@ bl_steering_motion_magic_controller
 	-->
 	</group>
 
-	<!--
 	<include file="$(find controller_node)/launch/teleop.launch"/>
-	<include file="$(find controller_node)/launch/path_follower.launch"/>
-	<include file="$(find behaviors)/launch/auto_node.launch"/>
 	<group ns="cmd_vel_mux">
 		<node name="twist_mux" pkg="twist_mux" type="twist_mux">
 			<rosparam command="load" file="$(find talon_swerve_drive_controller)/config/2022_twist_mux.yaml"/>
 			<remap from="cmd_vel_out" to="/frcrobot_jetson/swerve_drive_controller/cmd_vel"/>
 		</node>
 	</group>
+	<!--
+	<include file="$(find controller_node)/launch/path_follower.launch"/>
+	<include file="$(find behaviors)/launch/auto_node.launch"/>
 	-->
 
 

--- a/zebROS_ws/src/ros_control_boilerplate/config/2022_compbot_base_jetson.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2022_compbot_base_jetson.yaml
@@ -61,8 +61,8 @@ hardware_interface:
        - {name: br_angle, type: can_talon_fx, can_id: 14, local: true}
        - {name: bl_drive, type: can_talon_fx, can_id: 23, local: true}
        - {name: bl_angle, type: can_talon_fx, can_id: 13, local: true}
-       - {name: pdh, type: pdh}
-       - {name: pcm, type: pcm, pcm_id: 0}
+       # - {name: pdh, type: pdh}
+       # - {name: pcm, type: pcm, pcm_id: 0}
 
        - {name: robot_code_ready_jetson, local: true, type: ready}
        - {name: robot_code_ready_rio, local: false, type: ready} # Probably not really needed?

--- a/zebROS_ws/src/ros_control_boilerplate/config/2022_compbot_offsets.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2022_compbot_offsets.yaml
@@ -1,9 +1,9 @@
 swerve_drive_controller:
     steering_joint_bl:
-        offset: 6.05309
+        offset: 1.72113
     steering_joint_br:
-        offset: -2.41909
+        offset: 0.859029
     steering_joint_fl:
-        offset: 0.463262
+        offset: 1.12134
     steering_joint_fr:
-        offset: -3.63093
+        offset: -3.99909

--- a/zebROS_ws/src/ros_control_boilerplate/config/2022_swerve_drive.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2022_swerve_drive.yaml
@@ -16,7 +16,7 @@ swerve_drive_controller:
     ang_accel_conv: 2.0
     max_rotational_vel: 10 # TODO
 
-    f_s: 0.035
+    f_s: 0.0175
     f_a: 0.005 #use torque curve instead? TODO: FIX
     f_v: 0.00315528
 
@@ -46,8 +46,7 @@ swerve_drive_controller:
     speed_joint_fl:
         joint: fl_drive #fix pid
         close_loop_values:
-            - {p: 0.12, i: 0.0, d: 4.0, f: 0.042, i_zone: 650}
-            - {p: 0.1, i: 0.0, d: 10.0, f: 0.0, i_zone: 0}
+            - {p: 0.15, i: 0.0, d: 1.0, f: 0.043, i_zone: 0.0}
         sensor_phase: true
         invert_output: false
         feedback_type: IntegratedSensor
@@ -57,6 +56,8 @@ swerve_drive_controller:
         current_limit_enable: True
         dynamic_reconfigure: True
         neutral_mode: "Brake"
+        status_1_general_period: 100
+        status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
         status_3_quadrature_period: 250
@@ -77,8 +78,7 @@ swerve_drive_controller:
     speed_joint_fr:
         joint: fr_drive #fix pid
         close_loop_values:
-            - {p: 0.12, i: 0.0, d: 4.0, f: 0.042, i_zone: 650}
-            - {p: 0.1, i: 0.0, d: 10.0, f: 0.0, i_zone: 0}
+            - {p: 0.15, i: 0.0, d: 1.0, f: 0.043, i_zone: 0.0}
         sensor_phase: true
         invert_output: false
         feedback_type: IntegratedSensor
@@ -89,6 +89,8 @@ swerve_drive_controller:
         neutral_mode: "Brake"
         neutral_deadband: 0.01
         closed_loop_ramp: 0.25
+        status_1_general_period: 100
+        status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
         status_3_quadrature_period: 250
@@ -108,8 +110,8 @@ swerve_drive_controller:
     speed_joint_bl:
         joint: bl_drive #fix pid
         close_loop_values:
-            - {p: 0.12, i: 0.0, d: 4.0, f: 0.042, i_zone: 650}
-            - {p: 0.1, i: 0.0, d: 10.0, f: 0.0, i_zone: 0}
+            - {p: 0.15, i: 0.0, d: 1.0, f: 0.043, i_zone: 0.0}
+        sensor_phase: true
         feedback_type: IntegratedSensor
         sensor_phase: true
         invert_output: false
@@ -120,6 +122,8 @@ swerve_drive_controller:
         neutral_mode: "Brake"
         neutral_deadband: 0.01
         closed_loop_ramp: 0.25
+        status_1_general_period: 100
+        status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
         status_3_quadrature_period: 250
@@ -139,8 +143,7 @@ swerve_drive_controller:
     speed_joint_br:
         joint: br_drive #fix pid
         close_loop_values:
-            - {p: 0.12, i: 0.0, d: 4.0, f: 0.042, i_zone: 650}
-            - {p: 0.1, i: 0.0, d: 10.0, f: 0.0, i_zone: 0}
+            - {p: 0.15, i: 0.0, d: 1.0, f: 0.043, i_zone: 0.0}
         sensor_phase: True
         invert_output: false
         feedback_type: IntegratedSensor
@@ -151,6 +154,8 @@ swerve_drive_controller:
         neutral_mode: "Brake"
         neutral_deadband: 0.01
         closed_loop_ramp: 0.25
+        status_1_general_period: 100
+        status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
         status_3_quadrature_period: 250
@@ -184,6 +189,8 @@ swerve_drive_controller:
         motion_acceleration: 153.3
         voltage_compensation_enable: true
         dynamic_reconfigure: True
+        status_1_general_period: 100
+        status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
         status_3_quadrature_period: 250
@@ -217,6 +224,8 @@ swerve_drive_controller:
         motion_acceleration: 153.3
         voltage_compensation_enable: true
         dynamic_reconfigure: True
+        status_1_general_period: 100
+        status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
         status_3_quadrature_period: 250
@@ -250,6 +259,8 @@ swerve_drive_controller:
         motion_acceleration: 153.3
         voltage_compensation_enable: true
         dynamic_reconfigure: True
+        status_1_general_period: 100
+        status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
         status_3_quadrature_period: 250
@@ -283,6 +294,8 @@ swerve_drive_controller:
         motion_acceleration: 153.3
         voltage_compensation_enable: true
         dynamic_reconfigure: True
+        status_1_general_period: 100
+        status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
         status_3_quadrature_period: 250

--- a/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frc_robot_interface.cpp
@@ -2300,6 +2300,7 @@ bool FRCRobotInterface::initDevices(ros::NodeHandle root_nh)
 			// which means both reads and writes will be skipped
 			if (run_hal_robot_)
 			{
+				ROS_INFO_STREAM("Fake talon created at can ID " << can_ctre_mc_can_ids_[i]);
 				if (can_ctre_mc_is_talon_fx_[i])
 				{
 					ctre_mcs_.push_back(std::make_shared<ctre::phoenix::motorcontrol::can::WPI_TalonFX>(can_ctre_mc_can_ids_[i]));

--- a/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_hw_interface.cpp
+++ b/zebROS_ws/src/ros_control_boilerplate/src/frcrobot_hw_interface.cpp
@@ -77,7 +77,7 @@
 #include <hal/DriverStation.h>
 
 #include <ctre/phoenix/platform/can/PlatformCAN.h>           // for SetCANInterface
-//#include <ctre/phoenix/cci/Unmanaged_CCI.h>
+#include <ctre/phoenix/unmanaged/Unmanaged.h>
 
 extern "C" { void HALSIM_SetControlWord(HAL_ControlWord); }
 void HAL_SetCANBusString(const std::string &bus);
@@ -169,6 +169,7 @@ bool FRCRobotHWInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_
 			HAL_SendError(true, -1, false, "SetCANInterface failed - likely CAN adapter failure", "", "", true);
 		}
 		HAL_SetCANBusString(can_interface_);
+		ctre::phoenix::unmanaged::Unmanaged::SetPhoenixDiagnosticsStartTime(-1);
 	}
 
 	// Do base class init. This loads common interface info


### PR DESCRIPTION
Remove PCM status from jetson config
Only launch phoenix diagnostics on Rio
Tune swerve offsets and PID