### PR TITLE
Clean-up pass over 2022 configs

### DIFF
--- a/zebROS_ws/src/ros_control_boilerplate/config/2022_compbot_base_jetson.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2022_compbot_base_jetson.yaml
@@ -157,6 +157,8 @@ dynamic_arm_controller:
     invert_output: True
     neutral_mode: Brake
     dynamic_reconfigure: False
+    voltage_compensation_enable: True
+    voltage_compensation_saturation: 12
     status_1_general_period: 250 # default = 10
     status_2_feedback0_period: 250 # Default = 20
     status_3_quadrature_period: 250
@@ -187,7 +189,8 @@ shooter_controller:
   nominal_output_forward: 0.0
   nominal_output_reverse: 0.0
   voltage_compensation_enable: true
-  dynamic_reconfigure: True
+  voltage_compensation_saturation: 12
+  dynamic_reconfigure: False
   neutral_mode: Coast
   velocity_measurement_period: Period_20Ms
   velocity_measurement_window: 4
@@ -213,6 +216,9 @@ shooter_follower_controller:
   feedback_type: IntegratedSensor
   invert_output: False
   follow_joint: shooter_leader
+  enable_read_thread: False
+  voltage_compensation_enable: True
+  voltage_compensation_saturation: 12
   status_1_general_period: 250 # Default = 10
   status_2_feedback0_period: 250 # Default = 20
   status_3_quadrature_period: 250
@@ -238,6 +244,7 @@ intake_controller:
       joint: intake_motor
       invert_output: False  
       voltage_compensation_enable: True
+      voltage_compensation_saturation: 12
       dynamic_reconfigure: false
       status_1_general_period: 100 # Default = 10
       status_2_feedback0_period: 100 # Default = 20
@@ -329,6 +336,7 @@ indexer_straight_motor_controller:
     feedback_type: IntegratedSensor
     dynamic_reconfigure: True
     voltage_compensation_Enable: True
+    voltage_compensation_saturation: 12
 
 indexer_arc_motor_controller:
     type: talon_controllers/TalonPercentOutputController
@@ -337,6 +345,7 @@ indexer_arc_motor_controller:
     feedback_type: IntegratedSensor
     dynamic_reconfigure: True
     voltage_compensation_Enable: True
+    voltage_compensation_saturation: 12
 
 climber_motion_magic_controller:
     type: talon_controllers/TalonMotionMagicCloseLoopController
@@ -350,6 +359,7 @@ climber_motion_magic_controller:
     motion_cruise_velocity: 0.25
     motion_acceleration: 2
     voltage_compensation_enable: true
+    voltage_compensation_saturation: 12
     dynamic_reconfigure: true
     motion_s_curve_strength: 0
     conversion_factor: 0.00108
@@ -364,3 +374,5 @@ climber_follower_controller:
   follow_joint: climber_dynamic_arm_leader
   clear_position_on_limit_r: True
   neutral_mode: Brake
+  voltage_compensation_enable: true
+  voltage_compensation_saturation: 12

--- a/zebROS_ws/src/ros_control_boilerplate/config/2022_swerve_drive.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2022_swerve_drive.yaml
@@ -51,9 +51,12 @@ swerve_drive_controller:
         invert_output: false
         feedback_type: IntegratedSensor
         voltage_compensation_enable: True
+        voltage_compensation_saturation: 12
         current_limit_continuous_amps: 20
-        closed_loop_ramp: 0.25
+        current_limit_peak_amps: 40
+        current_limit_peak_msec: 100
         current_limit_enable: True
+        #closed_loop_ramp: 0.25
         dynamic_reconfigure: False
         neutral_mode: "Brake"
         status_1_general_period: 100
@@ -83,12 +86,15 @@ swerve_drive_controller:
         invert_output: false
         feedback_type: IntegratedSensor
         voltage_compensation_enable: True
+        voltage_compensation_saturation: 12
         current_limit_continuous_amps: 20
+        current_limit_peak_amps: 40
+        current_limit_peak_msec: 100
         current_limit_enable: True
         dynamic_reconfigure: False
         neutral_mode: "Brake"
         neutral_deadband: 0.01
-        closed_loop_ramp: 0.25
+        #closed_loop_ramp: 0.25
         status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
@@ -116,12 +122,15 @@ swerve_drive_controller:
         sensor_phase: true
         invert_output: false
         voltage_compensation_enable: True
+        voltage_compensation_saturation: 12
         current_limit_continuous_amps: 20
+        current_limit_peak_amps: 40
+        current_limit_peak_msec: 100
         current_limit_enable: True
         dynamic_reconfigure: False
         neutral_mode: "Brake"
         neutral_deadband: 0.01
-        closed_loop_ramp: 0.25
+        #closed_loop_ramp: 0.25
         status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
@@ -148,12 +157,15 @@ swerve_drive_controller:
         invert_output: false
         feedback_type: IntegratedSensor
         voltage_compensation_enable: True
+        voltage_compensation_saturation: 12
         current_limit_continuous_amps: 20
+        current_limit_peak_amps: 40
+        current_limit_peak_msec: 100
         current_limit_enable: True
         dynamic_reconfigure: False
         neutral_mode: "Brake"
         neutral_deadband: 0.01
-        closed_loop_ramp: 0.25
+        #closed_loop_ramp: 0.25
         status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
@@ -188,6 +200,7 @@ swerve_drive_controller:
         motion_cruise_velocity: 45
         motion_acceleration: 153.3
         voltage_compensation_enable: true
+        voltage_compensation_saturation: 12
         dynamic_reconfigure: False
         status_1_general_period: 100
         #status_2_feedback0_period: 100
@@ -223,6 +236,7 @@ swerve_drive_controller:
         motion_cruise_velocity: 45
         motion_acceleration: 153.3
         voltage_compensation_enable: true
+        voltage_compensation_saturation: 12
         dynamic_reconfigure: False
         status_1_general_period: 100
         #status_2_feedback0_period: 100
@@ -258,6 +272,7 @@ swerve_drive_controller:
         motion_cruise_velocity: 45
         motion_acceleration: 153.3
         voltage_compensation_enable: true
+        voltage_compensation_saturation: 12
         dynamic_reconfigure: False
         status_1_general_period: 100
         #status_2_feedback0_period: 100
@@ -293,6 +308,7 @@ swerve_drive_controller:
         motion_cruise_velocity: 45
         motion_acceleration: 153.3
         voltage_compensation_enable: true
+        voltage_compensation_saturation: 12
         dynamic_reconfigure: False
         status_1_general_period: 100
         #status_2_feedback0_period: 100

--- a/zebROS_ws/src/talon_controllers/include/talon_controllers/talon_controller_interface.h
+++ b/zebROS_ws/src/talon_controllers/include/talon_controllers/talon_controller_interface.h
@@ -663,14 +663,18 @@ class TalonCIParams
 		}
 		bool readVoltageCompensation(ros::NodeHandle &n)
 		{
-			int params_read = 0;
+			bool saturation_read = false;
 			if (n.getParam("voltage_compensation_saturation", voltage_compensation_saturation_))
-				params_read += 1;
+			{
+				saturation_read = true;
+			}
 			if (n.getParam("voltage_measurement_filter", voltage_measurement_filter_))
-				params_read += 1;
 			if (n.getParam("voltage_compensation_enable", voltage_compensation_enable_) &&
-				voltage_compensation_enable_ && (params_read < 2))
-				ROS_WARN("Not all voltage compensation params set before enabling - using defaults might not work as expected");
+				voltage_compensation_enable_ && !saturation_read)
+			{
+				ROS_WARN_STREAM("Using default voltage_compensation_saturation for " << joint_name_ <<
+					   " since value not set in config");
+			}
 			return true;
 		}
 
@@ -793,13 +797,13 @@ class TalonCIParams
 				param_count = 1;
 			if (n.getParam("softlimit_forward_enable", softlimit_forward_enable_) &&
 					softlimit_forward_enable_ && (param_count == 0))
-				ROS_WARN("Enabling forward softlimits without setting threshold");
+				ROS_WARN_STREAM("Enabling forward softlimits for " << joint_name_ << " without setting threshold");
 			param_count = 0;
 			if (n.getParam("softlimit_reverse_threshold", softlimit_reverse_threshold_))
 				param_count = 1;
 			if (n.getParam("softlimit_reverse_enable", softlimit_reverse_enable_) &&
 				softlimit_reverse_enable_ && (param_count == 0))
-					ROS_WARN("Enabling forward softlimits without setting threshold");
+					ROS_WARN_STREAM("Enabling forward softlimits for " << joint_name_ << " without setting threshold");
 			n.getParam("override_limit_switches_enable", override_limit_switches_enable_);
 			return true;
 		}
@@ -815,7 +819,8 @@ class TalonCIParams
 				params_read += 1;
 			if (n.getParam("current_limit_enable", current_limit_enable_) &&
 				current_limit_enable_ && (params_read < 3))
-				ROS_WARN("Not all current limits set before enabling - using defaults might not work as expected");
+				ROS_WARN_STREAM("Not all current limits set for " << joint_name_ <<
+						" before enabling - using defaults might not work as expected");
 			return true;
 		}
 
@@ -830,7 +835,8 @@ class TalonCIParams
 				params_read += 1;
 			if (n.getParam("supply_current_limit_enable", supply_current_limit_enable_) &&
 				current_limit_enable_ && (params_read < 3))
-				ROS_WARN("Not all supply current limits set before enabling - using defaults might not work as expected");
+				ROS_WARN_STREAM("Not all supply current limits set for " << joint_name_
+						<< " before enabling - using defaults might not work as expected");
 			return true;
 		}
 
@@ -845,7 +851,8 @@ class TalonCIParams
 				params_read += 1;
 			if (n.getParam("stator_current_limit_enable", stator_current_limit_enable_) &&
 				current_limit_enable_ && (params_read < 3))
-				ROS_WARN("Not all stator current limits set before enabling - using defaults might not work as expected");
+				ROS_WARN_STREAM("Not all stator current limits set for " << joint_name_ <<
+						" before enabling - using defaults might not work as expected");
 			return true;
 		}
 


### PR DESCRIPTION
Better warning messages from talon controller interface
Make sure everything is using voltage compensation enable
remove closed loop ramp rate from swerve drive wheels
Add complete set of current limiting to swerve drive wheels rather than
assuming default values