### PR TITLE
May have fixed PDH issue (in `test_pdh_ph` for now)

### DIFF
--- a/zebROS_ws/src/controller_node/launch/test_pdh_ph.launch
+++ b/zebROS_ws/src/controller_node/launch/test_pdh_ph.launch
@@ -28,7 +28,7 @@
 
 		<!-- Load controller manager -->
 		<node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-			output="screen" args="spawn joint_state_controller_rio match_state_controller pdh_state_controller ph_state_controller robot_controller_state_controller solenoid_controller robot_code_ready_controller" />
+			output="screen" args="spawn joint_state_controller_rio match_state_controller pdh_controller pdh_state_controller ph_state_controller robot_controller_state_controller solenoid_controller robot_code_ready_controller" />
 
 	</group>
 </launch>

--- a/zebROS_ws/src/ros_control_boilerplate/config/test_pdh_ph.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/test_pdh_ph.yaml
@@ -24,7 +24,7 @@ generic_hw_control_loop:
 # of several types of HW interface : CAN_id, PWM_id, DIO_id, AIO_id, etc.
 hardware_interface:
    joints:
-       # Need a single CTRE hardware device defined so the Rio 
+       # Need a single CTRE hardware device defined so the Rio
        # broadcasts keepalive / enable signals.  Without this, talons
        # controlled by the Jetson won't run. Use an unused CAN Id so that
        # the Rio sending 0'd control frames to it won't interfere with
@@ -35,13 +35,13 @@ hardware_interface:
        - {name: pdh, type: pdh, module: 1}
        - {name: ph, type: ph, ph_id: 1}
        - {name: robot_code_ready_rio, local: true, type: ready}
-         
+
 # Create controllers for each joint
 #
-# Entry is the name of the controller. It can be anything.  
+# Entry is the name of the controller. It can be anything.
 # It will create a namespace with that name under the main
 # controller namespace. Subscribed topics for that controller
-# will be most often show up under 
+# will be most often show up under
 # <top level controller manager ns>/<controller ns>/topic
 # e.g.
 # /frcrobot/joint1_talon_controller/command
@@ -74,6 +74,10 @@ ph_state_controller:
 
 pdh_state_controller:
     type: pdh_state_controller/PDHStateController
+    publish_rate: 20
+
+pdh_controller:
+    type: pdh_controller/PDHStateController
     publish_rate: 20
 
 solenoid_controller:


### PR DESCRIPTION
We weren't loading the `pdh_controller`, which is what takes care of sticky faults.

Added pdh_controller to spawn list and yaml file
Which allows us to `rosservice call /frcrobot_rio/pdh_controller/clear_faults`