### PR TITLE
Added wait for shooter to spin up again

### DIFF
--- a/zebROS_ws/src/behaviors/src/2022_shooting_server.cpp
+++ b/zebROS_ws/src/behaviors/src/2022_shooting_server.cpp
@@ -215,8 +215,8 @@ public:
           success = false;
           break;
         }
-        ros::Duration(0.75).sleep();
       }
+      ros::Duration(0.75).sleep();
 	    ros::spinOnce(); // update ball count, hopefully
     }
 


### PR DESCRIPTION
wasn't able to fully test because in sim speed stays constant even when disabled

Log:
```
[ INFO] [1647882176.933484180]: 2022_shooting_server : spinning up shooter
[ INFO] [1647882177.334051841]: 2022_shooting_server : spun up shooter
[ INFO] [1647882177.334165381]: 2022_shooting_server : getting cargo from indexer
[ INFO] [1647882178.344553636]: 2022_shooting_server : cargo should have been launched
[ INFO] [1647882178.344658624]: 2022_shooting_server : shooter is spinning fast enough, continuing
[ INFO] [1647882179.095127914]: 2022_shooting_server : getting cargo from indexer
[ INFO] [1647882184.025884145]: 2022_shooting_server : cargo should have been launched
[ INFO] [1647882184.026205329]: 2022_shooting_server : succeeded! yay!!
```