### PR TITLE
Udev rule for terabee

### DIFF
--- a/docker/docker-run-terabee
+++ b/docker/docker-run-terabee
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+dev_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+dev_dir="$( dirname "$dev_dir" )"
+
+set -e
+set -o pipefail
+
+docker run "$@" -it --net=host -v  /tmp/.X11-unix:/tmp/.X11-unix \
+ -v $HOME/2022RobotCode:/home/ubuntu/2022RobotCode \
+ --device=/dev/ttyACM0 \
+ -e DISPLAY=$DISPLAY --privileged --user ubuntu frc900/zebros-2022-dev:latest /bin/bash

--- a/scripts/jetson_setup/10-local.rules
+++ b/scripts/jetson_setup/10-local.rules
@@ -1,4 +1,4 @@
-ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", SYMLINK+="NAVX", MODE="0777"
+# ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", SYMLINK+="NAVX", MODE="0777"
 ACTION=="add", ATTRS{idVendor}=="26ac", ATTRS{idProduct}=="0015", SYMLINK+="PX4", MODE="0666"
 ACTION=="add", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="LIDAR", MODE="0777"
 ACTION=="add", ATTRS{idVendor}=="0451", ATTRS{idProduct}=="bef3", SYMLINK+="MMWAVE", MODE="0777"
@@ -6,3 +6,4 @@ ACTION=="add", ATTRS{idVendor}=="046D", ATTRS{idProduct}=="082d", SYMLINK+="C920
 ACTION=="add", ATTRS{idVendor}=="046D", ATTRS{idProduct}=="085c", SYMLINK+="C922", MODE="0777"
 ACTION=="add", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="ffee", SYMLINK+="ADI", MODE="0777"
 ACTION=="add", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000a", SYMLINK+="PICO", MODE="0777"
+ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", SYMLINK+="TERABEE", MODE="0777"


### PR DESCRIPTION
Wrote the docker-run-terabee script as well as the udev rule for the terabee. Also commented out the old udev rule for the old imu (uses the same vendorID and prodID as the terabee)