### PR TITLE
Don't re-zero when climb is reset

### DIFF
--- a/zebROS_ws/src/behaviors/src/2022_climb_server.cpp
+++ b/zebROS_ws/src/behaviors/src/2022_climb_server.cpp
@@ -151,7 +151,6 @@ public:
       nextFunction_ = boost::bind(&ClimbStateMachine::state1, this);
       rung = 0;
       driven_backwards_ = false;
-      climb_zeroed_ = false;
     }
     exited = false;
     success = false;


### PR DESCRIPTION
The arm only needs to be zeroed once. With the current code, if the climb were to be reset, the arm would zero before doing anything else which would probably slow us down.