### PR TITLE
Have controllers and hwi better handle non-monotonic time changes

### DIFF
--- a/zebROS_ws/ROSJetsonMaster.sh
+++ b/zebROS_ws/ROSJetsonMaster.sh
@@ -27,6 +27,10 @@ elif [ -f /home/admin/rio_bashrc.sh ] ; then
     export LD_LIBRARY_PATH=/home/admin/wpilib:$LD_LIBRARY_PATH
     swapon /dev/sda5
 	ulimit -r unlimited
+	# Update rio time and stop ntpd server to prevent
+	# time updates while robot code is running
+	/etc/init.d/ntpd stop
+	ntpd -gq
 else
     echo "Unknown environment! Trying to proceed anyway using local environment."
     source /opt/ros/melodic/setup.bash

--- a/zebROS_ws/src/as726x_controllers/src/as726x_state_controller.cpp
+++ b/zebROS_ws/src/as726x_controllers/src/as726x_state_controller.cpp
@@ -63,8 +63,12 @@ void AS726xStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void AS726xStateController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void AS726xStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	// limit rate of publishing
 	if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time)
 	{
@@ -72,7 +76,7 @@ void AS726xStateController::update(const ros::Time &time, const ros::Duration & 
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			// populate joint state message:
 			// - fill only joints that are present in the JointStateInterface, i.e. indices [0, num_hw_joints_)

--- a/zebROS_ws/src/frc_state_controllers/src/button_box_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/button_box_state_controller.cpp
@@ -41,13 +41,17 @@ namespace button_box_state_controller
 		last_publish_time_ = time;
 	}
 
-	void ButtonBoxStateController::update(const ros::Time &time, const ros::Duration & )
+	void ButtonBoxStateController::update(const ros::Time &time, const ros::Duration &period)
 	{
+		if (period < ros::Duration{0})
+		{
+			last_publish_time_ = time;
+		}
 		if ((publish_rate_ > 0.0) && (last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time))
 		{
 			if (realtime_pub_->trylock())
 			{
-				last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+				last_publish_time_ = time;
 
 				const auto &bbs = button_box_state_;
 				auto &m = realtime_pub_->msg_;

--- a/zebROS_ws/src/frc_state_controllers/src/joint_mode_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/joint_mode_state_controller.cpp
@@ -38,13 +38,17 @@ namespace joint_mode_state_controller
 		last_publish_time_ = time;
     }
 
-    void JointModeStateController::update(const ros::Time &time, const ros::Duration & )
+    void JointModeStateController::update(const ros::Time &time, const ros::Duration &period)
 	{
+		if (period < ros::Duration{0})
+		{
+			last_publish_time_ = time;
+		}
 		if ((publish_rate_ > 0.0) && (last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time))
 		{
 			if (realtime_pub_->trylock())
 			{
-				last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+				last_publish_time_ = time;
 
 				auto &m = realtime_pub_->msg_;
 

--- a/zebROS_ws/src/frc_state_controllers/src/joystick_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/joystick_state_controller.cpp
@@ -41,13 +41,17 @@ void JoystickStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void JoystickStateController::update(const ros::Time &time, const ros::Duration & )
+void JoystickStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	if ((publish_rate_ > 0.0) && (last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time))
 	{
 		if (realtime_pub_->trylock())
 		{
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			const auto &js = joystick_state_;
 			auto &m = realtime_pub_->msg_;

--- a/zebROS_ws/src/frc_state_controllers/src/match_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/match_state_controller.cpp
@@ -61,13 +61,17 @@ namespace match_state_controller
 		last_publish_time_ = time;
     }
 
-    void MatchStateController::update(const ros::Time &time, const ros::Duration & )
+    void MatchStateController::update(const ros::Time &time, const ros::Duration &period)
 	{
+		if (period < ros::Duration{0})
+		{
+			last_publish_time_ = time;
+		}
 		if ((publish_rate_ > 0.0) && (last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time))
 		{
 			if (realtime_pub_->trylock())
 			{
-				last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+				last_publish_time_ = time;
 
 				auto &m = realtime_pub_->msg_;
 

--- a/zebROS_ws/src/frc_state_controllers/src/pcm_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/pcm_state_controller.cpp
@@ -97,8 +97,12 @@ void PCMStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void PCMStateController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void PCMStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	// limit rate of publishing
 	if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time)
 	{
@@ -106,7 +110,7 @@ void PCMStateController::update(const ros::Time &time, const ros::Duration & /*p
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			auto &m = realtime_pub_->msg_;
 			m.header.stamp = time;

--- a/zebROS_ws/src/frc_state_controllers/src/pdh_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/pdh_state_controller.cpp
@@ -91,14 +91,18 @@ void PDHStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void PDHStateController::update(const ros::Time &time, const ros::Duration & )
+void PDHStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	//ROS_INFO_STREAM("pdh pub: " << publish_rate_);
 	if ((publish_rate_ > 0.0) && (last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time))
 	{
 		if (realtime_pub_->trylock())
 		{
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			auto &m = realtime_pub_->msg_;
 

--- a/zebROS_ws/src/frc_state_controllers/src/pdp_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/pdp_state_controller.cpp
@@ -60,14 +60,18 @@ void PDPStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void PDPStateController::update(const ros::Time &time, const ros::Duration & )
+void PDPStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	//ROS_INFO_STREAM("pdp pub: " << publish_rate_);
 	if ((publish_rate_ > 0.0) && (last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time))
 	{
 		if (realtime_pub_->trylock())
 		{
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			auto &m = realtime_pub_->msg_;
 

--- a/zebROS_ws/src/frc_state_controllers/src/ph_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/ph_state_controller.cpp
@@ -95,8 +95,12 @@ void PHStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void PHStateController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void PHStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	// limit rate of publishing
 	if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time)
 	{
@@ -104,7 +108,7 @@ void PHStateController::update(const ros::Time &time, const ros::Duration & /*pe
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			auto &m = realtime_pub_->msg_;
 			m.header.stamp = time;

--- a/zebROS_ws/src/frc_state_controllers/src/robot_controller_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/robot_controller_state_controller.cpp
@@ -37,13 +37,17 @@ void RobotControllerStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void RobotControllerStateController::update(const ros::Time &time, const ros::Duration & )
+void RobotControllerStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	if ((publish_rate_ > 0.0) && (last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time))
 	{
 		if (realtime_pub_->trylock())
 		{
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			auto &m = realtime_pub_->msg_;
 

--- a/zebROS_ws/src/spark_max_state_controller/src/spark_max_config_controller.cpp
+++ b/zebROS_ws/src/spark_max_state_controller/src/spark_max_config_controller.cpp
@@ -259,8 +259,12 @@ std::string SparkMaxConfigController::sensorTypeToString(hardware_interface::Sen
 	}
 }
 
-void SparkMaxConfigController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void SparkMaxConfigController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	// limit rate of publishing
 	if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time)
 	{
@@ -268,7 +272,7 @@ void SparkMaxConfigController::update(const ros::Time &time, const ros::Duration
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			// populate config message:
 			auto &m = realtime_pub_->msg_;

--- a/zebROS_ws/src/spark_max_state_controller/src/spark_max_state_controller.cpp
+++ b/zebROS_ws/src/spark_max_state_controller/src/spark_max_state_controller.cpp
@@ -135,8 +135,12 @@ std::string SparkMaxStateController::faultsToString(unsigned faults) const
 	return str;
 }
 
-void SparkMaxStateController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void SparkMaxStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	// limit rate of publishing
 	if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time)
 	{
@@ -144,7 +148,7 @@ void SparkMaxStateController::update(const ros::Time &time, const ros::Duration 
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			// populate joint state message:
 			// - fill only joints that are present in the JointStateInterface, i.e. indices [0, num_hw_joints_)

--- a/zebROS_ws/src/talon_state_controller/src/cancoder_state_controller.cpp
+++ b/zebROS_ws/src/talon_state_controller/src/cancoder_state_controller.cpp
@@ -94,8 +94,12 @@ void CANCoderStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void CANCoderStateController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void CANCoderStateController::update(const ros::Time &time, const ros::Duration & period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	// limit rate of publishing
 	if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time)
 	{
@@ -103,7 +107,7 @@ void CANCoderStateController::update(const ros::Time &time, const ros::Duration 
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			// populate joint state message:
 			// - fill only joints that are present in the JointStateInterface, i.e. indices [0, num_hw_joints_)

--- a/zebROS_ws/src/talon_state_controller/src/canifier_state_controller.cpp
+++ b/zebROS_ws/src/talon_state_controller/src/canifier_state_controller.cpp
@@ -149,8 +149,12 @@ void CANifierStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void CANifierStateController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void CANifierStateController::update(const ros::Time &time, const ros::Duration & period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	// limit rate of publishing
 	if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time)
 	{
@@ -158,7 +162,7 @@ void CANifierStateController::update(const ros::Time &time, const ros::Duration 
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			// populate joint state message:
 			// - fill only joints that are present in the JointStateInterface, i.e. indices [0, num_hw_joints_)

--- a/zebROS_ws/src/talon_state_controller/src/orchestra_state_controller.cpp
+++ b/zebROS_ws/src/talon_state_controller/src/orchestra_state_controller.cpp
@@ -51,8 +51,12 @@ void OrchestraStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void OrchestraStateController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void OrchestraStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	talon_state_msgs::InstrumentList instrument_list_holder;
 
 	// limit rate of publishing
@@ -62,7 +66,7 @@ void OrchestraStateController::update(const ros::Time &time, const ros::Duration
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			// populate joint state message:
 			// - fill only joints that are present in the JointStateInterface, i.e. indices [0, num_hw_joints_)

--- a/zebROS_ws/src/talon_state_controller/src/talon_config_controller.cpp
+++ b/zebROS_ws/src/talon_state_controller/src/talon_config_controller.cpp
@@ -339,8 +339,12 @@ std::string TalonConfigController::remoteSensorSourceToString(const hardware_int
 	}
 }
 
-void TalonConfigController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void TalonConfigController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	// limit rate of publishing
 	if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0 / publish_rate_) < time)
 	{
@@ -348,7 +352,7 @@ void TalonConfigController::update(const ros::Time &time, const ros::Duration & 
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			// populate joint state message:
 			// - fill only joints that are present in the JointStateInterface, i.e. indices [0, num_hw_joints_)

--- a/zebROS_ws/src/talon_state_controller/src/talon_state_controller.cpp
+++ b/zebROS_ws/src/talon_state_controller/src/talon_state_controller.cpp
@@ -125,8 +125,12 @@ void TalonStateController::starting(const ros::Time &time)
 	last_publish_time_ = time;
 }
 
-void TalonStateController::update(const ros::Time &time, const ros::Duration & /*period*/)
+void TalonStateController::update(const ros::Time &time, const ros::Duration &period)
 {
+	if (period < ros::Duration{0})
+	{
+		last_publish_time_ = time;
+	}
 	talon_state_msgs::CustomProfileStatus custom_profile_status_holder;
 
 	// limit rate of publishing
@@ -136,7 +140,7 @@ void TalonStateController::update(const ros::Time &time, const ros::Duration & /
 		if (realtime_pub_->trylock())
 		{
 			// we're actually publishing, so increment time
-			last_publish_time_ = last_publish_time_ + ros::Duration(1.0 / publish_rate_);
+			last_publish_time_ = time;
 
 			// populate joint state message:
 			// - fill only joints that are present in the JointStateInterface, i.e. indices [0, num_hw_joints_)


### PR DESCRIPTION
Include fixes for when ntpd changes time in jumps larger
than expected from the normal progress of time.
Also, add code to RIO startup to disable ntpd and force
a single time update before launching robot code to hopefully
avoid the problem entirely