### PR TITLE
Assorted joystick / drive base PID tuning and fixes

### DIFF
--- a/zebROS_ws/ROSJetsonMaster.sh
+++ b/zebROS_ws/ROSJetsonMaster.sh
@@ -31,7 +31,7 @@ elif [ -f /home/admin/rio_bashrc.sh ] ; then
 	killall PhoenixDiagnosticsProgram
 	# Force update to Rio time, hopefully will prevent
 	# time updates while robot code is running
-	#/etc/init.d/ntpd stop
+	/etc/init.d/ntpd stop
 	#ntpdate 10.9.0.8
 	#ntpd -gq
 	#/etc/init.d/ntpd restart
@@ -49,3 +49,7 @@ export ROSLAUNCH_SSH_UNKNOWN=1
 echo "ROS_IP set to $ROS_IP"
 
 exec "$@"
+
+if [ -f /home/admin/rio_bashrc.sh ] ; then
+	/etc/init.d/ntpd restart
+fi

--- a/zebROS_ws/src/frc_state_controllers/src/spacemouse_state_controller.cpp
+++ b/zebROS_ws/src/frc_state_controllers/src/spacemouse_state_controller.cpp
@@ -65,8 +65,8 @@ void update(const ros::Time &time, const ros::Duration &period) override
 
 			m.header.stamp = time;
 
-			m.leftStickX         = -js->getAxis(1);
-			m.leftStickY         = js->getAxis(0);
+			m.leftStickX         = js->getAxis(0);
+			m.leftStickY         = js->getAxis(1);
 			m.leftTrigger        = 0;
 			m.rightTrigger       = 0;
 			m.rightStickX        = js->getAxis(5);

--- a/zebROS_ws/src/ros_control_boilerplate/config/2022_swerve_drive.yaml
+++ b/zebROS_ws/src/ros_control_boilerplate/config/2022_swerve_drive.yaml
@@ -41,13 +41,14 @@ swerve_drive_controller:
     encoder_steering_set_units: 1
 
     wheel_coords: [[-0.27305, 0.27305], [0.27305, 0.27305], [-0.27305, -0.27305], [0.27305, -0.27305]]
-
+    parking_config_time_delay: 0.75
+    drive_speed_time_delay: 0.125
     cmd_vel_timeout: 0.5 # we test this separately, give plenty for the other tests
     use_cos_scaling: True # scale motor speed by how close angle motors are to setpoints
     speed_joint_fl:
         joint: fl_drive #fix pid
         close_loop_values:
-            - {p: 0.15, i: 0.0, d: 1.0, f: 0.043, i_zone: 0}
+            - {p: 0.15, i: 0.0, d: 8.0, f: 0.043, i_zone: 0}
         sensor_phase: true
         invert_output: false
         feedback_type: IntegratedSensor
@@ -58,9 +59,11 @@ swerve_drive_controller:
         current_limit_peak_msec: 50
         current_limit_enable: True
         closed_loop_ramp: 0.25
-        dynamic_reconfigure: False
+        dynamic_reconfigure: True
         neutral_mode: "Brake"
-        status_1_general_period: 100
+        velocity_measurement_period: Period_10Ms
+        velocity_measurement_window: 4
+        #status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
@@ -82,7 +85,7 @@ swerve_drive_controller:
     speed_joint_fr:
         joint: fr_drive #fix pid
         close_loop_values:
-            - {p: 0.15, i: 0.0, d: 1.0, f: 0.043, i_zone: 0}
+            - {p: 0.15, i: 0.0, d: 8.0, f: 0.043, i_zone: 0}
         sensor_phase: true
         invert_output: false
         feedback_type: IntegratedSensor
@@ -92,11 +95,13 @@ swerve_drive_controller:
         current_limit_peak_amps: 25
         current_limit_peak_msec: 50
         current_limit_enable: True
-        dynamic_reconfigure: False
+        dynamic_reconfigure: True
         neutral_mode: "Brake"
         neutral_deadband: 0.01
         closed_loop_ramp: 0.25
-        status_1_general_period: 100
+        velocity_measurement_period: Period_10Ms
+        velocity_measurement_window: 4
+        #status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
@@ -117,7 +122,7 @@ swerve_drive_controller:
     speed_joint_bl:
         joint: bl_drive #fix pid
         close_loop_values:
-            - {p: 0.15, i: 0.0, d: 1.0, f: 0.043, i_zone: 0}
+            - {p: 0.15, i: 0.0, d: 8.0, f: 0.043, i_zone: 0}
         sensor_phase: true
         feedback_type: IntegratedSensor
         sensor_phase: true
@@ -128,11 +133,13 @@ swerve_drive_controller:
         current_limit_peak_amps: 25
         current_limit_peak_msec: 50
         current_limit_enable: True
-        dynamic_reconfigure: False
+        dynamic_reconfigure: True
         neutral_mode: "Brake"
         neutral_deadband: 0.01
         closed_loop_ramp: 0.25
-        status_1_general_period: 100
+        velocity_measurement_period: Period_10Ms
+        velocity_measurement_window: 4
+        #status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
@@ -153,7 +160,7 @@ swerve_drive_controller:
     speed_joint_br:
         joint: br_drive #fix pid
         close_loop_values:
-            - {p: 0.15, i: 0.0, d: 1.0, f: 0.043, i_zone: 0}
+            - {p: 0.15, i: 0.0, d: 8.0, f: 0.043, i_zone: 0}
         sensor_phase: True
         invert_output: false
         feedback_type: IntegratedSensor
@@ -163,11 +170,13 @@ swerve_drive_controller:
         current_limit_peak_amps: 25
         current_limit_peak_msec: 50
         current_limit_enable: True
-        dynamic_reconfigure: False
+        dynamic_reconfigure: True
         neutral_mode: "Brake"
         neutral_deadband: 0.01
         closed_loop_ramp: 0.25
-        status_1_general_period: 100
+        velocity_measurement_period: Period_10Ms
+        velocity_measurement_window: 4
+        #status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
@@ -205,7 +214,7 @@ swerve_drive_controller:
         voltage_compensation_enable: true
         voltage_compensation_saturation: 12
         dynamic_reconfigure: False
-        status_1_general_period: 100
+        #status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
@@ -243,7 +252,7 @@ swerve_drive_controller:
         voltage_compensation_enable: true
         voltage_compensation_saturation: 12
         dynamic_reconfigure: False
-        status_1_general_period: 100
+        #status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
@@ -281,7 +290,7 @@ swerve_drive_controller:
         voltage_compensation_enable: true
         voltage_compensation_saturation: 12
         dynamic_reconfigure: False
-        status_1_general_period: 100
+        #status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20
@@ -319,7 +328,7 @@ swerve_drive_controller:
         voltage_compensation_enable: true
         voltage_compensation_saturation: 12
         dynamic_reconfigure: False
-        status_1_general_period: 100
+        #status_1_general_period: 100
         #status_2_feedback0_period: 100
         #status_1_general_period: 10
         #status_2_feedback0_period: 20

--- a/zebROS_ws/src/teleop_joystick_control/config/teleop_joystick_comp_2022.yaml
+++ b/zebROS_ws/src/teleop_joystick_control/config/teleop_joystick_comp_2022.yaml
@@ -6,10 +6,10 @@ teleop_params:
     max_speed: 3.0
     max_speed_slow: 0.75
     joystick_pow: 1.5
-    rotation_pow: 2.0   #Scaling factors used in teleop_joystick_comp
-    joystick_deadzone: 0.07
+    rotation_pow: 1.0   #Scaling factors used in teleop_joystick_comp
+    joystick_deadzone: 0.05
     drive_rate_limit_time: 200
-    rotate_rate_limit_time: 200
+    rotate_rate_limit_time: 500
     climber_align_angle: 3.14159265 # Intake facing DS wall
     trigger_threshold: 0.5
     stick_threshold: 0.5

--- a/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2022.cpp
+++ b/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2022.cpp
@@ -1,3 +1,7 @@
+// Toggle between rotation using rightStickX and rightTrigger - leftTrigger
+#define ROTATION_WITH_STICK
+
+
 #include "ros/ros.h"
 #include "frc_msgs/JoystickState.h"
 #include "sensor_msgs/JointState.h"
@@ -684,6 +688,7 @@ void evaluateCommands(const ros::MessageEvent<frc_msgs::JoystickState const>& ev
 
 		static ros::Time last_header_stamp = joystick_states_array[0].header.stamp;
 
+		teleop_cmd_vel->updateRateLimit(config);
 		geometry_msgs::Twist cmd_vel = teleop_cmd_vel->generateCmdVel(joystick_states_array[0], imu_angle, config);
 
 		if (cmd_vel.angular.z != 0.0) {
@@ -900,6 +905,7 @@ void evaluateCommands(const ros::MessageEvent<frc_msgs::JoystickState const>& ev
 			{
 			}
 
+#ifdef ROTATION_WITH_STICK
 			if(joystick_states_array[0].leftTrigger > config.trigger_threshold)
 			{
 				// Intake
@@ -940,6 +946,7 @@ void evaluateCommands(const ros::MessageEvent<frc_msgs::JoystickState const>& ev
 				// teleop_cmd_vel->setSlowMode(false);
 				joystick1_right_trigger_pressed = false;
 			}
+#endif
 		}
 		else
 		{


### PR DESCRIPTION

Add more d gain to drive base velocity motors to try and damp out oscillation at high accelerations
Reduce talon velocity filtering window on drive base velocity motors to try and damp out oscillation at high accelerations
Make ramp rate dynamic reconfigure actually change settings in code
Fix rotation ramp rate reading wrong config value

Fix spacemouse axis mapping