### PR TITLE
Remove swerve angle motor filtering

### DIFF
--- a/zebROS_ws/src/talon_swerve_drive_controller/include/talon_swerve_drive_controller/Swerve.h
+++ b/zebROS_ws/src/talon_swerve_drive_controller/include/talon_swerve_drive_controller/Swerve.h
@@ -93,20 +93,6 @@ class swerve
 
 		std::array<double, WHEELCOUNT> offsets_;
 
-		enum COMMAND_STATE
-		{
-			COMMAND_INVALID,
-			COMMAND_DRIVING,
-			COMMAND_PARKING
-		};
-
-		// Used for filtering jittery encoder values - cache previous direction
-		// and continue moving that way even if the wheel pos temporarily glitches
-		// over a value which would reverse the nearest-90-degree calculation
-		mutable std::array<bool, WHEELCOUNT> lastReverse_{false};
-		mutable std::array<double, WHEELCOUNT> lastCommand_{0};
-		mutable std::array<COMMAND_STATE, WHEELCOUNT> lastCommandState_{COMMAND_INVALID};
-
 		//Second piece of data is here just for physics/modeling
 
 		//std::array<double, WHEELCOUNT> savedEncoderVals_;

--- a/zebROS_ws/src/talon_swerve_drive_controller/src/Swerve.cpp
+++ b/zebROS_ws/src/talon_swerve_drive_controller/src/Swerve.cpp
@@ -56,26 +56,9 @@ std::array<Vector2d, WHEELCOUNT> swerve<WHEELCOUNT>::motorOutputs(Vector2d veloc
 		//ROS_INFO_STREAM("id: " << i << " PRE NORMalIZE pos/vel in direc: " << speedsAndAngles[i][0] << " rot: " <<speedsAndAngles[i][1] );
 		const double currpos = getWheelAngle(i, positionsNew[i]);
 		bool reverse;
-		double nearestangle = leastDistantAngleWithinHalfPi(currpos, speedsAndAngles[i][1], reverse);
-		// In some cases when the wheels are near 90 degrees off from where they are commanded
-		// noise from the encoder will have them jump back and forth trying to go
-		// one direction then then next as the noise changes which side of the 90 degree
-		// offset they are at.  Add hystersis here to prevent the oscillation
-		if ((lastCommandState_[i] == COMMAND_DRIVING) && (reverse != lastReverse_[i]) && (fabs(currpos - nearestangle) > 85 * M_PI / 180))
-		{
-			//ROS_ERROR_STREAM("setting to last command = " << lastCommand_[i]);
-			reverse = lastReverse_[i];
-			nearestangle = lastCommand_[i];
-		}
-		else
-		{
-			//ROS_INFO_STREAM("setting to actual command; currpos - nearest angle = " << currpos - nearestangle << " and reverse changed is " << (reverse != lastReverse_[i]));
-			lastReverse_[i] = reverse;
-			lastCommand_[i] = nearestangle;
-			lastCommandState_[i] = COMMAND_DRIVING;
-		}
+		const double nearestangle = leastDistantAngleWithinHalfPi(currpos, speedsAndAngles[i][1], reverse);
 
-		// ROS_INFO_STREAM("wheel " << i << " currpos: " << currpos << " nearestangle: " << nearestangle << " reverse: " << reverse);
+		//ROS_INFO_STREAM("wheel " << i << " currpos: " << currpos << " nearestangle: " << nearestangle << " reverse: " << reverse);
 		// Slow down wheels the further they are from their target
 		// angle. This will help to prevent wheels which are in the process
 		// of getting to the correct orientation from dragging the robot
@@ -98,19 +81,7 @@ std::array<double, WHEELCOUNT> swerve<WHEELCOUNT>::parkingAngles(const std::arra
 	{
 		const double currpos = getWheelAngle(i, positionsNew[i]);
 		bool reverse;
-		double nearestanglep = leastDistantAngleWithinHalfPi(currpos, swerveMath_.getParkingAngle(i), reverse);
-		if ((lastCommandState_[i] == COMMAND_PARKING) && (reverse != lastReverse_[i]) && (fabs(currpos - nearestanglep) > 85 * M_PI / 180))
-		{
-			//ROS_ERROR_STREAM("setting to last command = " << lastCommand_[i]);
-			nearestanglep = lastCommand_[i];
-		}
-		else
-		{
-			//ROS_INFO_STREAM("setting to actual command; currpos - nearest angle = " << currpos - nearestanglep << " and reverse changed is " << (reverse != lastReverse_[i]));
-			lastReverse_[i] = reverse;
-			lastCommand_[i] = nearestanglep;
-			lastCommandState_[i] = COMMAND_PARKING;
-		}
+		const double nearestanglep = leastDistantAngleWithinHalfPi(currpos, swerveMath_.getParkingAngle(i), reverse);
 
 		retAngles[i] = nearestanglep * units_.steeringSet + offsets_[i];
 		//ROS_INFO_STREAM(" id: " << i << " currpos: " << currpos << " target: " << nearestanglep);

--- a/zebROS_ws/src/talon_swerve_drive_controller/src/test_filtering.cpp
+++ b/zebROS_ws/src/talon_swerve_drive_controller/src/test_filtering.cpp
@@ -1,9 +1,18 @@
+#include <ros/console.h>
 #include <cmath>
 #include "talon_swerve_drive_controller/Swerve.h"
 
+constexpr size_t WHEELCOUNT = 4;
+void print(const std::array<double, WHEELCOUNT> &positions, const std::array<Eigen::Vector2d, WHEELCOUNT> &speedsAngles)
+{
+	ROS_INFO_STREAM("===============================");
+	for (size_t i = 0; i < WHEELCOUNT; i++)
+		ROS_INFO_STREAM("\ti=" << i << " position=" << positions[i] << " speed=" << speedsAngles[i][0] << " angle=" << speedsAngles[i][1]);
+}
+
+
 int main(void)
 {
-	constexpr size_t WHEELCOUNT = 4;
 	std::array<Eigen::Vector2d, WHEELCOUNT> wheel_coords_;
 	std::array<double, WHEELCOUNT> offsets{0};
 	for (auto &w: wheel_coords_)
@@ -29,10 +38,10 @@ int main(void)
 
 	std::array<double, WHEELCOUNT> positions;
 
-	positions[0] = 0;
-	positions[1] = 0;
-	positions[2] = 0;
-	positions[3] = 0;
+	positions[0] = 0.01;
+	positions[1] = -0.01;
+	positions[2] = 0.01;
+	positions[3] = -0.01;
 	Eigen::Vector2d linearV;
 	double rotation;
 
@@ -43,12 +52,21 @@ int main(void)
 	linearV[1] = 0;
 	rotation = 0;
 	auto speedsAngles = swerveC.motorOutputs(linearV, rotation, angle, positions, true);
-	positions[0] = 0.01;
+	print(positions, speedsAngles);
+	positions[0] = speedsAngles[0][1] - 0.01;
+	positions[1] = speedsAngles[1][1] + 0.01;
+	positions[2] = speedsAngles[2][1] - 0.01;
+	positions[3] = speedsAngles[3][1] + 0.01;
+	linearV[0] = 0;
+	linearV[1] = 1;
 	speedsAngles = swerveC.motorOutputs(linearV, rotation, angle, positions, true);
+	print(positions, speedsAngles);
+#if 0
 	auto angles = swerveC.parkingAngles(positions);
 	speedsAngles = swerveC.motorOutputs(linearV, rotation, angle, positions, true);
 
 	angles = swerveC.parkingAngles(positions);
 	angles[0] += M_PI / 2 + 0.01;
 	angles = swerveC.parkingAngles(angles);
+#endif
 }


### PR DESCRIPTION
This removes code which tries to prevent unneeded reversals
in swerve angle motor rotation.  It was broken for cases which
require near-90* changes in swerve angle, leading to us dragging
wheels while driving.